### PR TITLE
Bump eslint to 2.1.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,9 +10,10 @@ standard have defined.
 In your project folder:
 
 ```
+npm install --save-dev eslint@2.3.0
 npm install --save-dev eslint-config-clock
-npm install --save-dev eslint-config-standard
-npm install --save-dev eslint-plugin-standard
+npm install --save-dev eslint-config-standard@5.1.0
+npm install --save-dev eslint-plugin-standard@1.3.1
 ```
 
 Then create a `.eslintrc` in the project root.

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "url": "git@github.com:clocklimited/eslint-config-clock"
   },
   "peerDependencies": {
-    "eslint": "^1.3.1",
-    "eslint-config-standard": "^4.3.1",
-    "eslint-plugin-standard": "^1.3.0"
+    "eslint": "^2.1.0",
+    "eslint-config-standard": "^5.1.0",
+    "eslint-plugin-standard": "^1.3.1"
   }
 }


### PR DESCRIPTION
Makes `eslint-config-clock` work with `npm@2` and `npm@3`. Also works with the latest version of eslint (`2.3.0`) installed.

The lint rule [no-path-concat](http://eslint.org/docs/rules/no-path-concat) is the only major rule that fails on projects using the existing config. In our applications this will require `browjadify@2.6.0`.
